### PR TITLE
Resolved 2 resource leaks in main() and write()

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -57,118 +57,6 @@
         </plugins>
     </build>
 
-    <profiles>
-        <profile>
-            <id>checkerframework</id>
-            <!-- If you omit the activation block, run mvn with "-P checkerframework" to run checkers. -->
-            <activation>
-                <jdk>[1.8,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.10.1</version>
-                        <configuration>
-                            <fork>true</fork> <!-- Must fork or else JVM arguments are ignored. -->
-                            <annotationProcessorPaths>
-                                <path>
-                                    <groupId>org.checkerframework</groupId>
-                                    <artifactId>checker</artifactId>
-                                    <version>3.39.0</version>
-                                </path>
-                            </annotationProcessorPaths>
-                            <annotationProcessors>
-                                <!-- Add all the checkers you want to enable here -->
-                                <annotationProcessor>org.checkerframework.checker.resourceleak.ResourceLeakChecker
-                                </annotationProcessor>
-                            </annotationProcessors>
-                            <compilerArgs>
-                                <arg>-Xmaxerrs</arg>
-                                <arg>10000</arg>
-                                <arg>-Xmaxwarns</arg>
-                                <arg>10000</arg>
-                                <arg>-Awarns</arg>
-                                <!-- <arg>-Awarns</arg> --> <!-- -Awarns turns type-checking errors into warnings. -->
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>checkerframework-jdk8</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
-            <properties>
-                <javac.version>9+181-r4173-1</javac.version>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <!-- This plugin execution will copy the com.google.errorprone:javac jar file to
-                             your project’s output directory without adding that jar as an explicit
-                             dependency. -->
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>copy</goal>
-                                </goals>
-                                <phase>process-sources</phase>
-                                <configuration>
-                                    <artifact>com.google.errorprone:javac:${javac.version}:jar</artifact>
-                                    <outputDirectory>${project.build.directory}/javac</outputDirectory>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <compilerArgs combine.children="append">
-                                <arg>-J-Xbootclasspath/p:${project.build.directory}/javac/javac-${javac.version}.jar</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>checkerframework-jdk9orlater</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <compilerArgs combine.children="append">
-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
-                                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -180,12 +68,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.5.6</version>
-        </dependency>
-        <!-- Annotations from the Checker Framework: nullness, interning, locking, ... -->
-        <dependency>
-            <groupId>org.checkerframework</groupId>
-            <artifactId>checker-qual</artifactId>
-            <version>3.39.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -57,6 +57,118 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>checkerframework</id>
+            <!-- If you omit the activation block, run mvn with "-P checkerframework" to run checkers. -->
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.10.1</version>
+                        <configuration>
+                            <fork>true</fork> <!-- Must fork or else JVM arguments are ignored. -->
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.checkerframework</groupId>
+                                    <artifactId>checker</artifactId>
+                                    <version>3.39.0</version>
+                                </path>
+                            </annotationProcessorPaths>
+                            <annotationProcessors>
+                                <!-- Add all the checkers you want to enable here -->
+                                <annotationProcessor>org.checkerframework.checker.resourceleak.ResourceLeakChecker
+                                </annotationProcessor>
+                            </annotationProcessors>
+                            <compilerArgs>
+                                <arg>-Xmaxerrs</arg>
+                                <arg>10000</arg>
+                                <arg>-Xmaxwarns</arg>
+                                <arg>10000</arg>
+                                <arg>-Awarns</arg>
+                                <!-- <arg>-Awarns</arg> --> <!-- -Awarns turns type-checking errors into warnings. -->
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>checkerframework-jdk8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
+            <properties>
+                <javac.version>9+181-r4173-1</javac.version>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <!-- This plugin execution will copy the com.google.errorprone:javac jar file to
+                             your project’s output directory without adding that jar as an explicit
+                             dependency. -->
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <phase>process-sources</phase>
+                                <configuration>
+                                    <artifact>com.google.errorprone:javac:${javac.version}:jar</artifact>
+                                    <outputDirectory>${project.build.directory}/javac</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerArgs combine.children="append">
+                                <arg>-J-Xbootclasspath/p:${project.build.directory}/javac/javac-${javac.version}.jar</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>checkerframework-jdk9orlater</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerArgs combine.children="append">
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -68,6 +180,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.5.6</version>
+        </dependency>
+        <!-- Annotations from the Checker Framework: nullness, interning, locking, ... -->
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+            <version>3.39.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/server/src/main/java/com/server/Server.java
+++ b/server/src/main/java/com/server/Server.java
@@ -171,11 +171,15 @@ public class Server {
          */
         private void write(Message msg) throws IOException {
             for (ObjectOutputStream writer : writers) {
-                msg.setUserlist(names);
-                msg.setUsers(users);
-                msg.setOnlineCount(names.size());
-                writer.writeObject(msg);
-                writer.reset();
+                try {
+                    msg.setUserlist(names);
+                    msg.setUsers(users);
+                    msg.setOnlineCount(names.size());
+                    writer.writeObject(msg);
+                    writer.reset();
+                } finally {
+                    writer.close();
+                }
             }
         }
 

--- a/server/src/main/java/com/server/Server.java
+++ b/server/src/main/java/com/server/Server.java
@@ -50,7 +50,7 @@ public class Server {
         private ObjectOutputStream output;
         private InputStream is;
 
-        public Handler( Socket socket) throws IOException {
+        public Handler(Socket socket) throws IOException {
             this.socket = socket;
         }
 

--- a/server/src/main/java/com/server/Server.java
+++ b/server/src/main/java/com/server/Server.java
@@ -28,10 +28,9 @@ public class Server {
     public static void main(String[] args) throws Exception {
         logger.info("The chat server is running.");
         ServerSocket listener = new ServerSocket(PORT);
-
-        try {
+        try(Socket s = listener.accept()){
             while (true) {
-                new Handler(listener.accept()).start();
+                new Handler(s).start();
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -51,7 +50,7 @@ public class Server {
         private ObjectOutputStream output;
         private InputStream is;
 
-        public Handler(Socket socket) throws IOException {
+        public Handler( Socket socket) throws IOException {
             this.socket = socket;
         }
 

--- a/server/src/main/java/com/server/Server.java
+++ b/server/src/main/java/com/server/Server.java
@@ -28,6 +28,7 @@ public class Server {
     public static void main(String[] args) throws Exception {
         logger.info("The chat server is running.");
         ServerSocket listener = new ServerSocket(PORT);
+
         try(Socket s = listener.accept()){
             while (true) {
                 new Handler(s).start();


### PR DESCRIPTION
In the main() function, a socket is opened via the listener.accept() function, but is not closed. Resolved this issue with a try-with-resource approach where we instantiate the socket in the try header and substitute that into the code.

in the write() function, the writer object is opened but never closed. Resolved this by adding a finally block and closing writer. 